### PR TITLE
Add descriptions for en-US with fastlane directory layout

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,30 @@
+<p>Foreground is an easy to use task manager app. Designed to be beautiful,
+simple and unintrusive, Foreground helps you know what needs done without
+getting in your way. Foreground also supports syncing with <a
+href="https://taskwarrior.org/">Taskwarrior</a> servers.</p>
+
+<h2 id="syncing">Syncing</h2>
+
+<p>To set up sync, add your taskwarrior server credentials (provided by your
+taskd server or a service like inthe.am or FreeCinc) to the settings menu, and
+enable sync using the toggle. A test will be run to check if the settings are
+valid, and the enable will stick if the config works. You can also configure
+automatic syncing in this menu, or click the sync button on the main page to
+start a sync.</p>
+
+<h2 id="implementation-details">Implementation Details</h2>
+
+<p>Unlike existing Taskwarrior apps for Android, Foreground does not run the
+taskwarrior binary inside, but rather implements a taskwarrior sync client.
+This allows for greater device compatibility and simplifies UI development but
+it can cause issues when syncing if not done correctly.</p>
+
+<h2 id="current-limitations">Current Limitations</h2>
+
+<p>Foreground currently supports most features of Taskwarrior. Notable
+exceptions involve handling of recurring events and display/editing of User
+Defined Attributes. Recurring event instances created by other clients will be
+shown by Foreground, but Foreground does not create recurring event instances
+of its own at this time.  User Defined attributes are preserved internally but
+are not yet exposed for viewing or editing.  These limitations will be resolved
+in future releases.</p>

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+Task manager app, supporting syncing with Taskwarrior.


### PR DESCRIPTION
This is needed so descriptions can be added to F-Droid, while keeping most metadata here. Tackles https://github.com/bgregos/foreground/issues/20 . If you'd like to keep this info at F-Droid feel free to close this @bgregos , I only think it makes sense since you already publish this on Google Play.