### PR TITLE
Recyclerview fixes

### DIFF
--- a/app/src/main/java/me/bgregos/foreground/TaskListActivity.kt
+++ b/app/src/main/java/me/bgregos/foreground/TaskListActivity.kt
@@ -224,7 +224,6 @@ class TaskListActivity : AppCompatActivity(), PopupMenu.OnMenuItemClickListener 
     }
 
     private val broadcastReceiver = object : BroadcastReceiver() {
-        @Synchronized
         override fun onReceive(context: Context, intent: Intent?) {
             when (intent?.action) {
                 "BRIGHTTASK_REMOTE_TASK_UPDATE" -> {

--- a/app/src/main/java/me/bgregos/foreground/TaskListActivity.kt
+++ b/app/src/main/java/me/bgregos/foreground/TaskListActivity.kt
@@ -224,6 +224,7 @@ class TaskListActivity : AppCompatActivity(), PopupMenu.OnMenuItemClickListener 
     }
 
     private val broadcastReceiver = object : BroadcastReceiver() {
+        @Synchronized
         override fun onReceive(context: Context, intent: Intent?) {
             when (intent?.action) {
                 "BRIGHTTASK_REMOTE_TASK_UPDATE" -> {
@@ -234,7 +235,6 @@ class TaskListActivity : AppCompatActivity(), PopupMenu.OnMenuItemClickListener 
                     syncButton?.startAnimation(syncRotateAnimation)
 
                     LocalTasks.updateVisibleTasks()
-                    setupRecyclerView(task_list)
                     task_list.adapter?.notifyDataSetChanged()
                     Log.i("auto_sync", "Task List received auto-update")
                 }
@@ -270,15 +270,11 @@ class TaskListActivity : AppCompatActivity(), PopupMenu.OnMenuItemClickListener 
         private val onClickListener: View.OnClickListener
 
         init {
+            this.setHasStableIds(false)
             onClickListener = View.OnClickListener { v ->
                 val task = v.tag as Task
                 parentActivity.openTask(task, v, task.name)
             }
-        }
-
-        fun swap(){
-            values.clear()
-            values.addAll(LocalTasks.visibleTasks)
         }
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {

--- a/app/src/main/java/me/bgregos/foreground/TaskListActivity.kt
+++ b/app/src/main/java/me/bgregos/foreground/TaskListActivity.kt
@@ -296,21 +296,16 @@ class TaskListActivity : AppCompatActivity(), PopupMenu.OnMenuItemClickListener 
             }
 
             holder.complete.setOnClickListener {
-                val pos = LocalTasks.items.indexOf(item)
-                val visiblePos = LocalTasks.visibleTasks.indexOf(item)
-                removeAt(position)
+                val pos = holder.layoutPosition
+                values.removeAt(pos)
+                notifyItemRemoved(pos)
+                //notifyItemRangeChanged(pos, values.size)
                 item.modifiedDate=Date().toUtc() //update modified date
                 item.status = "completed"
                 if (!LocalTasks.localChanges.contains(item)){
                     LocalTasks.localChanges.add(item)
                 }
             }
-        }
-
-        fun removeAt(position:Int) {
-            values.removeAt(position)
-            notifyItemRemoved(position)
-            notifyItemRangeChanged(position, values.size-1)
         }
 
         override fun getItemCount() = values.size


### PR DESCRIPTION
This should solve a long-standing bug where removing multiple tasks could cause "ghost" tasks to appear or cause existing ones to display incorrectly.