### PR TITLE
Filter for exact tag matches

### DIFF
--- a/app/src/main/java/me/bgregos/foreground/model/TaskFilter.kt
+++ b/app/src/main/java/me/bgregos/foreground/model/TaskFilter.kt
@@ -88,7 +88,7 @@ class TaskFiltersAvailable {
                 id = "tag",
                 parameterFormat = ParameterFormat.STRING,
                 filter = { task: Task, param: String? ->
-                    task.tags.any { t -> t.contains(param ?: return@TaskFilterType false) }
+                    task.tags.any { t -> t == param}
                 },
                 autocomplete = { task -> task.tags }
             ),


### PR DESCRIPTION
Currently tags are matched on substrings, so an exclude-filter for the tag `in` would also exclude tasks with tag `server_admin`.
This MR changes this behaviour to filter only on exact matches of the tag.

I am not entirely sure if the current behavior was by design, so please comment if that is the case.