### PR TITLE
Only show autocomplete suggestions once

### DIFF
--- a/app/src/main/java/me/bgregos/foreground/tasklist/TaskViewModel.kt
+++ b/app/src/main/java/me/bgregos/foreground/tasklist/TaskViewModel.kt
@@ -253,6 +253,7 @@ class TaskViewModel @Inject constructor(
         return withContext(Dispatchers.Default) {
             return@withContext tasks.value.flatMap { filterType.autocomplete(it) }
                 .filter { it.lowercase().contains(filterParameter.lowercase()) }
+                .distinct()
         }
     }
 


### PR DESCRIPTION
It could happen that the same tag was shown multiple times in the autocomplete suggestion. This MR fixes this.

![Screenshot_20230520-183107_Foreground](https://github.com/bgregos/foreground/assets/1565989/9fbfdcf2-d20c-4bc0-bf86-e70e76b8f38d)
