### PR TITLE
Improve Tags selection experience

### DIFF
--- a/app/src/main/java/me/bgregos/foreground/tasklist/TaskDetailFragment.kt
+++ b/app/src/main/java/me/bgregos/foreground/tasklist/TaskDetailFragment.kt
@@ -335,6 +335,15 @@ class TaskDetailFragment : Fragment() {
             viewModel.currentTask?.let { viewModel.delete(it) }
         }
 
+        binding.actionSave.setOnClickListener {
+            if (twoPane) {
+                activity?.supportFragmentManager?.beginTransaction()?.tabletDetailAnimations()
+                        ?.remove(this@TaskDetailFragment)?.commit()
+            } else {
+                activity?.supportFragmentManager?.popBackStack()
+            }
+        }
+
         return binding.root
     }
 

--- a/app/src/main/java/me/bgregos/foreground/tasklist/TaskViewModel.kt
+++ b/app/src/main/java/me/bgregos/foreground/tasklist/TaskViewModel.kt
@@ -114,6 +114,16 @@ class TaskViewModel @Inject constructor(
         }
     }
 
+    fun allTags(): Set<String> {
+        val tags = mutableSetOf<String>()
+
+        tasks.value?.forEach { task ->
+            task.tags.forEach { tag -> tags.add(tag) }
+        }
+
+        return tags
+    }
+
     private fun updatePendingNotifications() {
         notificationRepository.scheduleNotificationForTasks(tasks.value ?: ArrayList())
     }

--- a/app/src/main/res/layout/fragment_task_detail.xml
+++ b/app/src/main/res/layout/fragment_task_detail.xml
@@ -167,6 +167,18 @@
             android:layout_margin="2dp"
             android:layout_gravity="end" />
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/action_save"
+            style="@style/Widget.MaterialComponents.Button.TextButton.Icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_margin="2dp"
+            android:text="@string/save"
+            android:textColor="#FFFFFF"
+            app:icon="@drawable/ic_baseline_description_24"
+            app:iconTint="#FFFFFF" />
+
     </LinearLayout>
     
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_task_detail.xml
+++ b/app/src/main/res/layout/fragment_task_detail.xml
@@ -59,18 +59,26 @@
 
             </com.google.android.material.textfield.TextInputLayout>
 
-            <com.google.android.material.textfield.TextInputLayout
-                android:layout_marginBottom = "10dp"
+            <TextView
+                android:id="@+id/label_tags"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Tags" />
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/tags_chipgroup"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/detail_tags"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="Tags"/>
+            </com.google.android.material.chip.ChipGroup>
 
-            </com.google.android.material.textfield.TextInputLayout>
+            <EditText
+                android:id="@+id/detail_newTag"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ems="5"
+                android:hint="new tag"
+                android:inputType="text" />
 
             <TextView
                 android:layout_width="match_parent"
@@ -180,7 +188,7 @@
             app:iconTint="#FFFFFF" />
 
     </LinearLayout>
-    
+
 </LinearLayout>
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,7 @@
     <string name="add_task">Add Task</string>
     <string name="delete">Delete</string>
     <string name="complete">Mark Completed</string>
+    <string name="save">Save</string>
     <string name="select_filter_type">Select Filter Type</string>
     <string name="add_a_filter">Add a filter</string>
     <string name="filter_add_warning">Please fill out all fields before adding.</string>


### PR DESCRIPTION
I found having to manually type tags every time tedious. This PR proposes a slight change in the user interface which uses Chip element to provide user with an easy, one-tap selection for any of the existing tags, but also allows them to create new ones if needed.

#### Pixel 6
![pixel6_tags_chups](https://github.com/bgregos/foreground/assets/183976/7e97192e-3688-4d78-ab2b-75fa765ef572)

#### Pixel Tablet
![pixel_tablet_tags_chips](https://github.com/bgregos/foreground/assets/183976/e88f1adb-aa88-4df6-8340-d96cca47fcbb)


#### Small Phone
![smallphone_tags_chips](https://github.com/bgregos/foreground/assets/183976/b11d15c5-80f4-4aef-9972-c3395ce0b2e0)



This PR includes #177 (which can be closed if that one is to be merged). If I should  rebase it on the master instead, please let me know. #177 did not include screenshots for small devices, this one does.